### PR TITLE
[FIX][SLOT-226] Fix services cache

### DIFF
--- a/src/app/services/SpecificSlotService.ts
+++ b/src/app/services/SpecificSlotService.ts
@@ -30,7 +30,11 @@ export const SpecificSlotService = createApi({
       onQueryStarted: async (_, { dispatch, queryFulfilled }) => {
         await queryFulfilled;
         dispatch(
-          UserService.util.invalidateTags(["userCalendar", "userSlots"]),
+          UserService.util.invalidateTags([
+            "userCalendar",
+            "userSlots",
+            "userStudents",
+          ]),
         );
       },
     }),

--- a/src/app/services/UserService.ts
+++ b/src/app/services/UserService.ts
@@ -107,6 +107,7 @@ export const UserService = createApi({
         body: { capacity },
       }),
       invalidatesTags: (_result, _error, { userId }) => [
+        "userCalendar",
         { type: "userSlots", id: userId },
         { type: "userPreferences", id: userId },
       ],


### PR DESCRIPTION
- Ya funciona que al cancelar un turno se limpia la cache de los estudiantes con turnos a recuperar, haciendo que si un alumno está recuperando un turno y ese turno se cancela, sigue apareciendo esa recuperación pendiente. 

- También cuando se edita la capacidad de los turnos se actualiza la caché del calendario apareciendo el número máximo de capacidad correspondiente en el turno


