### PR TITLE
[ENH][SLOT-228] Disable search filter for canceled a slot

### DIFF
--- a/src/components/filter_search/FilterSearch.tsx
+++ b/src/components/filter_search/FilterSearch.tsx
@@ -1,10 +1,7 @@
-import SearchIcon from "../../assets/search.svg"
-import {
-  FilterInputStyled,
-  IconWrapper,
-  FilterDiv,
-} from "./FilterSearch.styles";
+import SearchIcon from "../../assets/search.svg";
+import * as s from "./FilterSearch.styles";
 import { useEffect, useState } from "react";
+import { NEUTRAL_COLOR } from "../../utils/Stylesheet";
 
 interface FilterSearchProps {
   placeholder?: string;
@@ -13,6 +10,7 @@ interface FilterSearchProps {
   debounceTime?: number;
   iconWidth?: number;
   iconHeight?: number;
+  disabled?: boolean;
 }
 
 const FilterSearch: React.FC<FilterSearchProps> = ({
@@ -21,7 +19,8 @@ const FilterSearch: React.FC<FilterSearchProps> = ({
   onChange,
   debounceTime = 400,
   iconWidth = 15,
-  iconHeight = 15
+  iconHeight = 15,
+  disabled = false,
 }) => {
   const [internalValue, setInternalValue] = useState(value);
 
@@ -46,17 +45,26 @@ const FilterSearch: React.FC<FilterSearchProps> = ({
   };
 
   return (
-    <FilterDiv>
-      <FilterInputStyled
+    <s.FilterDiv>
+      <s.FilterInputStyled
         type="text"
         placeholder={placeholder}
         value={internalValue}
         onChange={handleChange}
+        disabled={disabled}
       />
-      <IconWrapper >
-        <img src={SearchIcon} width={iconWidth} height={iconHeight}></img>
-      </IconWrapper>
-    </FilterDiv>
+      <s.IconWrapper>
+        <img
+          src={SearchIcon}
+          width={iconWidth}
+          height={iconHeight}
+          style={{
+            filter: disabled ? "grayscale(100%) opacity(0.5)" : "none",
+            cursor: disabled ? "not-allowed" : "default",
+          }}
+        ></img>
+      </s.IconWrapper>
+    </s.FilterDiv>
   );
 };
 

--- a/src/pages/calendar/slot/SpecificSlotActions.tsx
+++ b/src/pages/calendar/slot/SpecificSlotActions.tsx
@@ -124,9 +124,7 @@ function Slot(props: SlotParams) {
   const [filter, setFilter] = useState<string>("");
 
   const { data: filteredStudents } = useGetSpecificSlotStudentsQuery(
-    slot.id && slot.status !== "CANCELED" && filter
-      ? { specificSlotId: slot.id, filter }
-      : skipToken,
+    filter ? { specificSlotId: slot.id, filter } : skipToken,
   );
 
   const handleAbsenceSlot = (student: Student, specificSlotId: string) => {
@@ -149,7 +147,6 @@ function Slot(props: SlotParams) {
     });
   };
   const handleCancelSlot = (specificSlotId: string) => {
-    if (!slot || !dayOfWeek) return;
     setFilter("");
     setSlotAction({
       type: "CANCEL",

--- a/src/pages/calendar/slot/SpecificSlotActions.tsx
+++ b/src/pages/calendar/slot/SpecificSlotActions.tsx
@@ -43,6 +43,7 @@ const ActionsSkeleton = ({
           value={filter}
           onChange={setFilter}
           placeholder="Buscar"
+          disabled={isCanceled}
         />
       </s.SearchFilterContainer>
       <s.ActionGroup>
@@ -123,7 +124,9 @@ function Slot(props: SlotParams) {
   const [filter, setFilter] = useState<string>("");
 
   const { data: filteredStudents } = useGetSpecificSlotStudentsQuery(
-    slot?.id ? { specificSlotId: slot.id, filter: filter } : skipToken,
+    slot.id && slot.status !== "CANCELED" && filter
+      ? { specificSlotId: slot.id, filter }
+      : skipToken,
   );
 
   const handleAbsenceSlot = (student: Student, specificSlotId: string) => {
@@ -147,6 +150,7 @@ function Slot(props: SlotParams) {
   };
   const handleCancelSlot = (specificSlotId: string) => {
     if (!slot || !dayOfWeek) return;
+    setFilter("");
     setSlotAction({
       type: "CANCEL",
       specificSlotId,


### PR DESCRIPTION
Se deshabilita el filtro de búsqueda cuando un turno está cancelado, además si se escibe un nombre y se cancela el turno, se limpia el filtro para que no quede el nombre.
Y le agregué que el icono se vea más gris cuando se deshabilita.
<img width="387" height="357" alt="image" src="https://github.com/user-attachments/assets/348b5792-7031-4709-89d4-b6a6d01d56b0" />
