### PR TITLE
[FIX][SLOT-225] Clear payment day for beginning of month

### DIFF
--- a/src/pages/students/forms/paymentDataForm/PaymentData.scheme.ts
+++ b/src/pages/students/forms/paymentDataForm/PaymentData.scheme.ts
@@ -1,15 +1,14 @@
 import * as yup from "yup";
 import { PaymentPlanName } from "../../../../app/types/models/PaymentPlanName";
 
-
 export const paymentDataScheme = yup.object().shape({
-
-  paymentPlanName: yup
-    .string().required("Debe seleccionar un plan de pago"),
+  paymentPlanName: yup.string().required("Debe seleccionar un plan de pago"),
 
   extraClasses: yup
     .number()
-    .transform((value, originalValue) => (originalValue === "" ? undefined : value))
+    .transform((value, originalValue) =>
+      originalValue === "" ? undefined : value,
+    )
     .typeError("Solo se permiten números")
     .notRequired()
     .when(["paymentPlanName", "$actionType"], {
@@ -20,18 +19,14 @@ export const paymentDataScheme = yup.object().shape({
           .typeError("Solo se permiten números")
           .max(7, "No puede superar 7 clases")
           .min(0, "No puede ser negativo")
-          .test(
-            "validateDay",
-            "Debe ingresar las clases extras",
-            (value) => {
-              const today = new Date();
-              const dayOfMonth = today.getDate();
-              if (dayOfMonth > 10) {
-                return value !== undefined && value !== null;
-              }
-              return true;
+          .test("validateDay", "Debe ingresar las clases extras", (value) => {
+            const today = new Date();
+            const dayOfMonth = today.getDate();
+            if (dayOfMonth > 10) {
+              return value !== undefined && value !== null;
             }
-          )
+            return true;
+          })
           .notRequired(),
       otherwise: (schema) => schema.notRequired(),
     }),
@@ -50,18 +45,14 @@ export const paymentDataScheme = yup.object().shape({
         schema
           .typeError("Solo se permiten números")
           .min(0, "No puede ser negativo")
-          .test(
-            "validateDay",
-            "Debe ingresar el precio",
-            (value) => {
-              const today = new Date();
-              const dayOfMonth = today.getDate();
-              if (dayOfMonth > 10) {
-                return value !== undefined && value !== null;
-              }
-              return true;
+          .test("validateDay", "Debe ingresar el precio", (value) => {
+            const today = new Date();
+            const dayOfMonth = today.getDate();
+            if (dayOfMonth > 10) {
+              return value !== undefined && value !== null;
             }
-          )
+            return true;
+          })
           .notRequired(),
       otherwise: (schema) => schema.notRequired(),
     }),
@@ -80,4 +71,3 @@ export const paymentDataScheme = yup.object().shape({
       otherwise: (schema) => schema.notRequired(),
     }),
 });
-

--- a/src/pages/students/forms/paymentDataForm/PaymentData.tsx
+++ b/src/pages/students/forms/paymentDataForm/PaymentData.tsx
@@ -1,57 +1,51 @@
-import {
-  MainContainer,
-  FormContainer,
-  Label,
-  Input,
-  Select,
-  InputsContainer,
-  Text,
-  SecondaryInputsContainer
-} from "./PaymentData.styles";
+import * as s from "./PaymentData.styles";
 import { Controller, useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
 import { paymentDataScheme } from "./PaymentData.scheme";
-import { ErrorMessage } from "../../../../components/error_message/ErrorMessage"
+import { ErrorMessage } from "../../../../components/error_message/ErrorMessage";
 import type { FormProp } from "../../create-student/FormProp.type";
-import { PaymentPlanName, PlanTypeNameArray } from "../../../../app/types/models/PaymentPlanName";
-import CurrencyInput from "../../../../utils/InputPrice/CurrencyInput"
+import {
+  PaymentPlanName,
+  PlanTypeNameArray,
+} from "../../../../app/types/models/PaymentPlanName";
+import CurrencyInput from "../../../../utils/InputPrice/CurrencyInput";
 import { forwardRef, useImperativeHandle } from "react";
 
 export interface PaymentDataProps {
   paymentPlanName: string;
-  extraClasses?: number | null | undefined;
-  classPrice?: number | null | undefined;
-  paymentDay?: number | undefined;
+  extraClasses?: number | null;
+  classPrice?: number | null;
+  paymentDay?: number;
 }
 
-const PaymentData = forwardRef<FormProp<PaymentDataProps>, FormProp<PaymentDataProps>>((props, ref) => {
-
+const PaymentData = forwardRef<
+  FormProp<PaymentDataProps>,
+  FormProp<PaymentDataProps>
+>((props, ref) => {
   const { data, onSubmit: onSubmit, actionType } = props;
 
   type FormData = yup.InferType<typeof paymentDataScheme>;
 
   const DEFAULT_PAYMENT_DATA: PaymentDataProps = {
     paymentPlanName: "",
-    extraClasses: null,
-    classPrice: undefined,
-    paymentDay: undefined
   };
 
-  const studentRegistrationForm = data || DEFAULT_PAYMENT_DATA;
+  const studentRegistrationForm = data ?? DEFAULT_PAYMENT_DATA;
 
   const {
     register,
     handleSubmit,
     watch,
     control,
+    setValue,
     formState: { errors },
   } = useForm<FormData>({
     resolver: yupResolver(paymentDataScheme) as any,
     defaultValues: { ...studentRegistrationForm },
     context: {
       actionType: actionType,
-    }
+    },
   });
 
   const PaymentPlanNameSelected = watch("paymentPlanName");
@@ -59,34 +53,42 @@ const PaymentData = forwardRef<FormProp<PaymentDataProps>, FormProp<PaymentDataP
   const NoPaymentSelectedSkeleton = () => {
     return (
       <div>
-        <Text $isRegister={actionType !== 'edit'}>Este campo se habilitará una vez seleccione el plan de pago.</Text>
-        <Input disabled={PaymentPlanNameSelected === ""}></Input>
+        <s.Text $isRegister={actionType !== "edit"}>
+          Este campo se habilitará una vez seleccione el plan de pago.
+        </s.Text>
+        <s.Input disabled={PaymentPlanNameSelected === ""}></s.Input>
       </div>
-    )
-  }
+    );
+  };
   const SpecificDaySkeleton = () => {
     return (
       <>
-        <Label>Día de pago</Label>
-        <Input placeholder="15"  {...register("paymentDay")} />
+        <s.Label>Día de pago</s.Label>
+        <s.Input placeholder="15" {...register("paymentDay")} />
         <ErrorMessage error={errors.paymentDay} />
       </>
-    )
-  }
+    );
+  };
   const BeginningOfMonthSkeleton = () => {
     {
       return (
-        <InputsContainer>
-          <Text $isRegister={actionType !== 'edit'}> Si el alumno empezó luego del día 10, puede indicar
-            la cantidad de clases extras para realizar el primer pago.</Text>
-          <SecondaryInputsContainer>
+        <s.InputsContainer>
+          <s.Text $isRegister={actionType !== "edit"}>
+            Si el alumno empezó luego del día 10, puede indicar la cantidad de
+            clases extras para realizar el primer pago.
+          </s.Text>
+          <s.SecondaryInputsContainer>
             <div>
-              <Label>Clases extras</Label>
-              <Input $isSmallSize placeholder="Clases extras" {...register("extraClasses")}></Input>
+              <s.Label>Clases extras</s.Label>
+              <s.Input
+                $isSmallSize
+                placeholder="Clases extras"
+                {...register("extraClasses")}
+              ></s.Input>
               <ErrorMessage error={errors.extraClasses} />
             </div>
             <div>
-              <Label>Precio clase individual</Label>
+              <s.Label>Precio clase individual</s.Label>
               <Controller
                 name="classPrice"
                 control={control}
@@ -101,56 +103,83 @@ const PaymentData = forwardRef<FormProp<PaymentDataProps>, FormProp<PaymentDataP
               />
               <ErrorMessage error={errors.classPrice} />
             </div>
-          </SecondaryInputsContainer>
-        </InputsContainer>
-      )
+          </s.SecondaryInputsContainer>
+        </s.InputsContainer>
+      );
     }
-  }
+  };
 
-
-  useImperativeHandle(ref, () => ({
-    submit: () =>
-      new Promise<boolean>((resolve) => {
-        handleSubmit(
-          (data) => {
-            onSubmit?.({ ...data });
-            resolve(true);
-          },
-          () => {
-            resolve(false);
-          }
-        )();
-      })
-  }) as unknown as FormProp<PaymentDataProps>);
+  useImperativeHandle(
+    ref,
+    () =>
+      ({
+        submit: () =>
+          new Promise<boolean>((resolve) => {
+            handleSubmit(
+              (data) => {
+                onSubmit?.({ ...data });
+                resolve(true);
+              },
+              () => {
+                resolve(false);
+              },
+            )();
+          }),
+      }) as unknown as FormProp<PaymentDataProps>,
+  );
 
   return (
-    <MainContainer>
-      <FormContainer>
+    <s.MainContainer>
+      <s.FormContainer>
         <div>
-          <Label>Plan de pago</Label>
-          <Select {...register("paymentPlanName")} defaultValue="">
-            <option value="" disabled hidden>Seleccione una opción</option>
-            {PlanTypeNameArray.map((planType) => (
-              <option key={planType} value={planType}>{planType}</option>
-            ))}
-          </Select>
+          <s.Label>Plan de pago</s.Label>
+          <Controller
+            name="paymentPlanName"
+            control={control}
+            defaultValue=""
+            render={({ field }) => (
+              <s.Select
+                {...field}
+                onChange={(e) => {
+                  const value = e.target.value;
+                  field.onChange(value);
+
+                  if (value === PaymentPlanName.BEGINNING_OF_MONTH) {
+                    setValue("paymentDay", undefined);
+                  }
+
+                  if (value === PaymentPlanName.SPECIFIC_DAY) {
+                    setValue("extraClasses", undefined);
+                    setValue("classPrice", undefined);
+                  }
+                }}
+              >
+                <option value="" disabled hidden>
+                  Seleccione una opción
+                </option>
+                {PlanTypeNameArray.map((planType) => (
+                  <option key={planType} value={planType}>
+                    {planType}
+                  </option>
+                ))}
+              </s.Select>
+            )}
+          />
+
           <ErrorMessage error={errors.paymentPlanName} />
         </div>
         <div>
-          {PaymentPlanNameSelected === "" && (
-            <NoPaymentSelectedSkeleton />
-          )}
+          {PaymentPlanNameSelected === "" && <NoPaymentSelectedSkeleton />}
           {PaymentPlanNameSelected === PaymentPlanName.SPECIFIC_DAY && (
             <SpecificDaySkeleton />
           )}
-          {PaymentPlanNameSelected === PaymentPlanName.BEGINNING_OF_MONTH && actionType !== 'edit' && (
-            <BeginningOfMonthSkeleton />)}
+          {PaymentPlanNameSelected === PaymentPlanName.BEGINNING_OF_MONTH &&
+            actionType !== "edit" && <BeginningOfMonthSkeleton />}
         </div>
-      </FormContainer>
-    </MainContainer>
-  )
+      </s.FormContainer>
+    </s.MainContainer>
+  );
 });
 
-
-PaymentData.displayName = 'PaymentDataForm';
+PaymentData.displayName = "PaymentDataForm";
 export default PaymentData;


### PR DESCRIPTION
Tarea:

> Al registrar un estudiante y seleccionamos el plan “Dia especifico“ y cargamos un dia, pero despues modificamos el plan a “Principio de mes” y finalizamos el flujo de crear estudiante, se devuelve un error porque estamos mandando el dia de pago en el plan “Principio de mes” cuando el campo deberia haberse limpiado al momento de cambiar de plan

Ahora se limpia el campo "Día de pago" cuando se cambia de "Día Especifico" a "Principio de Mes", haciendo que el registro del estudiante sea exitoso si pasa esa situación. Lo mismo si sucede al revés, de "Principio de Mes" a "Día Especifico" se limpian los campos de "Clases extras" y de "Precio individual". 