### PR TITLE
[FIX][SLOT-213] Remove padding-top

### DIFF
--- a/src/components/header/header.styles.ts
+++ b/src/components/header/header.styles.ts
@@ -68,7 +68,6 @@ export const Option = styled.div<OptionProps>`
   img {
     width: ${({ $hasImg }) => ($hasImg ? "16px" : "0")};
     height: ${({ $hasImg }) => ($hasImg ? "16px" : "0")};
-    padding-top: ${({ $hasImg }) => ($hasImg ? "4px" : "0")};
   }
 `;
 


### PR DESCRIPTION
Se eliminó el padding para que se centre correctamente el icono del signo más en el header:
<img width="213" height="71" alt="image" src="https://github.com/user-attachments/assets/50c6950a-133c-483c-8bb2-001d1ca03fd6" />
Así estaba: 
<img width="232" height="86" alt="image" src="https://github.com/user-attachments/assets/f97c78d0-3158-4f39-9dbc-3b1b458df4ce" />
