### PR TITLE
[ENH][SLOT-205] Hide pathologies field when is empty

### DIFF
--- a/src/pages/student_detail/StudentDetail.tsx
+++ b/src/pages/student_detail/StudentDetail.tsx
@@ -210,10 +210,12 @@ const StudentData = ({
           </InformationContainer>
         ))}
       </AllInformationContainer>
-      <InformationContainer key={"Patologías"}>
-        <Label>Patologías</Label>
-        <StudentInfo>{student.pathologies}</StudentInfo>
-      </InformationContainer>
+      {student.pathologies && student.pathologies.trim() !== "" && (
+        <InformationContainer key={"Patologías"}>
+          <Label>Patologías</Label>
+          <StudentInfo>{student.pathologies}</StudentInfo>
+        </InformationContainer>
+      )}
     </StudentInfoContainer>
   );
 };


### PR DESCRIPTION
Ahora cuando no se ingresa una patología, no se muestra en el detalle del alumno para que quede visualmente más limpio:
Ejemplo:
<img width="1687" height="543" alt="image" src="https://github.com/user-attachments/assets/b6f402d4-e1b9-4aea-8c82-349cee52718e" />
