### PR TITLE
[ENH][SLOT-230]: Add brand_color for current day in calendar

### DIFF
--- a/src/app/types/responses/CalendarResponse.type.ts
+++ b/src/app/types/responses/CalendarResponse.type.ts
@@ -2,6 +2,7 @@
 export type Day = {
     dayOfWeek: string;
     numberOfDay: number;
+    current: boolean;
 };
 
 export type SlotTime = {

--- a/src/pages/calendar/CalendarViewPage.styles.ts
+++ b/src/pages/calendar/CalendarViewPage.styles.ts
@@ -126,11 +126,15 @@ export const DayOfWeek = styled.h1`
   font-size: ${DEFAULT_FONT_SIZE};
 `;
 
-export const Number = styled.span`
+export interface NumberProps {
+  $isCurrentDay?: boolean;
+}
+
+export const Number = styled.span<NumberProps>`
   width: 32px;
   height: 32px;
   border-radius: 50%;
-  background-color: ${LIGHT_NEUTRAL_COLOR};
+  background-color: ${(props) => (props.$isCurrentDay ? BRAND_COLOR : LIGHT_NEUTRAL_COLOR)};
   font-weight: ${FONT_WEIGHT_BOLD};
   font-family: ${FONT_FAMILY};
   color: ${DEFAULT_TEXT_COLOR};

--- a/src/pages/calendar/CalendarViewPage.tsx
+++ b/src/pages/calendar/CalendarViewPage.tsx
@@ -21,26 +21,29 @@ import { CalendarMonth } from "../../utils/MonthsOfYear";
 import InputDate from "../../components/date/inputDate";
 export type CalendarAction =
   | {
-      type: "ABSENCE";
-      studentId: string;
-      studentName: string;
-      specificSlotId: string;
-    }
+    type: "ABSENCE";
+    studentId: string;
+    studentName: string;
+    specificSlotId: string;
+  }
   | { type: "RECOVER"; specificSlotId: string; availableCapacity: number }
   | {
-      type: "CANCEL";
-      specificSlotId: string;
-      dayOfWeek: string;
-      slot: { startTime: string; endTime: string };
-    };
+    type: "CANCEL";
+    specificSlotId: string;
+    dayOfWeek: string;
+    slot: { startTime: string; endTime: string };
+  };
 
 function CalendarView() {
+
   const { userId } = useAuthentication();
 
   const [selectDate, setSelectDate] = useState<Date>(new Date());
 
   const [markAbsence] = useMarkStudentAbsenceMutation();
+
   const [slotAction, setSlotAction] = useState<CalendarAction | null>(null);
+
   const closeModal = () => setSlotAction(null);
 
   const { data: calendarData } = useGetCalendarViewQuery({
@@ -135,7 +138,7 @@ function CalendarView() {
           <s.DayColumn key={day.dayOfWeek}>
             <s.DayContainer>
               <s.DayOfWeek>{DaysOfWeekTranslation[day.dayOfWeek]}</s.DayOfWeek>
-              <s.Number>{day.numberOfDay}</s.Number>
+              <s.Number $isCurrentDay={day.current}>{day.numberOfDay}</s.Number>
             </s.DayContainer>
             {calendarData?.times.map((_, rowIndex) => {
               const slot = calendarData.slots[rowIndex][colIndex];


### PR DESCRIPTION
Se agregó el atributo current a la response del calendario y la prop correspondiente para que cuando el turno sea del dia actual se marque en amarillo