### PR TITLE
[FIX][SLOT-250] Add max limit

### DIFF
--- a/src/pages/slots/forms/EditCapacity.scheme.ts
+++ b/src/pages/slots/forms/EditCapacity.scheme.ts
@@ -5,5 +5,6 @@ export const EditCapacityScheme = yup.object().shape({
     .number()
     .required('Debe ingresar un número')
     .typeError('Debe ingresar un número')
-    .min(1, 'El cupo debe ser al menos 1'),
+    .min(1, 'El cupo debe ser al menos 1')
+    .max(127, 'El cupo no puede exceder 127'),
 });


### PR DESCRIPTION
Agregué en las validaciones que no se pueda ingresar más de 127 como cupo ya que asi está definido en el backend.
Otra cosa es que antes de hacer la validación, probé ingresar 128 y sale este error del back que está raro: 
<img width="914" height="644" alt="image" src="https://github.com/user-attachments/assets/afb58aa7-4c09-49f8-b2e1-9061c140f21e" />
Lo dejo por si quedó mal ese error en el backend @Fedesan14 