### PR TITLE
[ENH][SLOT-233] Modify dia de pago for dia de vencimiento

### DIFF
--- a/src/pages/student_fees_list/FeesList.tsx
+++ b/src/pages/student_fees_list/FeesList.tsx
@@ -199,7 +199,7 @@ function StudentFeesList() {
           {student?.name} {student?.lastName}
         </s.SubTitle>
         <s.SubTitle>Cantidad de días: {student?.numberOfDays}</s.SubTitle>
-        <s.SubTitle>Día de pago: {student?.paymentDay}</s.SubTitle>
+        <s.SubTitle>Día de vencimiento: {student?.paymentDay}</s.SubTitle>
       </s.InformationStudent>
       <s.MetricsContainer>
         <PaymentMetrics studentId={student.id} />


### PR DESCRIPTION
Se cambió el texto "día de pago" por "día de vencimiento" en el listado de cuotas:
<img width="437" height="92" alt="image" src="https://github.com/user-attachments/assets/e0127db0-298d-4388-a4a6-1bd4a498241e" />
