### PR TITLE
[FIX][SLOT-249]: Fix font-family

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -30,3 +30,11 @@ body {
   margin: 0;
   font-family: 'Inter', sans-serif;
 }
+
+button,
+input,
+textarea,
+select {
+  font-family: inherit;
+  font-size: inherit;
+}


### PR DESCRIPTION
Estuve viendo y parece ser que el problema era que algunos elementos HTML como button, input, textarea, select no heredan font-family por defecto en los navegadores porque tienen sus propios estilos del sistema operativo que sobreescriben la herencia.
La solución que encontré fue agregar un reset explícito en el index.css
Creo que ahi quedó todo bien seteado