### PR TITLE
[ENH][SLOT-241]: Improve empty state message when there are no slots …

### DIFF
--- a/src/components/slotRegistrationCalendar/SlotRegistrationCalendar.styles.tsx
+++ b/src/components/slotRegistrationCalendar/SlotRegistrationCalendar.styles.tsx
@@ -77,6 +77,4 @@ export const WarningContainer = styled.div`
   width: 100%;
   display: flex;
   justify-content: center;
-  border-right: 5px solid ${LIGHT_NEUTRAL_COLOR};
-  border-top: 5px solid ${LIGHT_NEUTRAL_COLOR};
 `;

--- a/src/components/slotRegistrationCalendar/SlotRegistrationCalendar.tsx
+++ b/src/components/slotRegistrationCalendar/SlotRegistrationCalendar.tsx
@@ -8,6 +8,7 @@ import {
 import { SUCCESS_COLOR } from '../../utils/Stylesheet';
 import type { Slot } from '../slotDetail/SlotDetail';
 import { DaysOfWeekTranslation } from '../../utils/DaysOfWeek';
+import { SearchNotFound } from '../search_not_found/SearchNotFound';
 type DayWithSlots = { day: string; slots: Slot[] };
 type CalendarProps = {
   selectedSlots: { id: string }[];
@@ -39,7 +40,9 @@ function SlotRegistrationCalendar({
 }
 export default SlotRegistrationCalendar;
 const WarningMessage = () => (
-  <WarningContainer>No hay turnos disponibles para los próximos días.</WarningContainer>
+  <WarningContainer>
+    <SearchNotFound message='Aún no hay turnos registrados.'></SearchNotFound>
+  </WarningContainer>
 );
 const Slots = ({ selectedSlots, onSelectSlot, onDeleteSlot, listSlots }: CalendarProps) => {
   const maxTurnos = Math.max(...listSlots.map((day) => day.slots.length));


### PR DESCRIPTION
Agregué el componente reutilizable de SearchNotFound para cuando no hay turnos disponibles. El mensaje ya estaba centrado de otra tarea

<img width="1292" height="601" alt="image" src="https://github.com/user-attachments/assets/6bd41782-a761-4f19-8969-56b5591e9569" />
