### PR TITLE
[FIX][SLOT-259]: Fix dni bug when we want to edit student data

### DIFF
--- a/src/pages/students/forms/studentDataForm/StudentData.tsx
+++ b/src/pages/students/forms/studentDataForm/StudentData.tsx
@@ -52,12 +52,19 @@ const StudentData = forwardRef<FormRef, FormProps<StudentDataProps>>((props, ref
       ...studentRegistrationForm,
     },
   });
+
   const [validateStudentDni] = useValidateStudentDniMutation();
+
   useImperativeHandle(ref, () => ({
     submit: () =>
       new Promise<boolean>((resolve) => {
         handleSubmit(
           (data) => {
+            if (data.dni === studentRegistrationForm.dni) {
+              onSubmit?.(data);
+              resolve(true);
+              return;
+            }
             validateStudentDni({ dni: data.dni })
               .unwrap()
               .then(() => {


### PR DESCRIPTION
Al editar datos de un estudiante, saltaba la validación del dni y no te dejaba registrar los cambios ya que el dni ya existía. Agregué una validación en el onSubmit de studentData, si el dni del form===dniOriginal no hace la validación y permite editar correctamente