### PR TITLE
[BUG][SLOT-277]:Make amountOfDays input read-only, update validation …

### DIFF
--- a/src/components/date/inputDate.styles.ts
+++ b/src/components/date/inputDate.styles.ts
@@ -7,6 +7,7 @@ import {
   BORDER_RADIUS,
   DEFAULT_FONT_SIZE,
   SMALL_FONT_SIZE,
+  MEDIUM_FONT_SIZE,
 } from '../../utils/Stylesheet';
 
 interface StyledWrapperProps {
@@ -35,14 +36,14 @@ export const StyledWrapper = styled.div<StyledWrapperProps>`
     z-index: 9999;
 
     ${(props) =>
-      props.$calendarPosition === 'top'
-        ? `
+    props.$calendarPosition === 'top'
+      ? `
           bottom: 100%;
           left: 0;
           margin-bottom: 4px;
 
         `
-        : `
+      : `
           top: 100%;
           left: 0;
           margin-top: 4px;
@@ -97,7 +98,7 @@ export const StyledWrapper = styled.div<StyledWrapperProps>`
   }
 
   .react-date-picker__inputGroup {
-    font-size: ${DEFAULT_FONT_SIZE};
+    font-size: ${MEDIUM_FONT_SIZE};
   }
 
   //HOVER SOBRE DIAS

--- a/src/pages/plans/EditPlan/EditPlan.scheme.ts
+++ b/src/pages/plans/EditPlan/EditPlan.scheme.ts
@@ -3,16 +3,12 @@ import * as yup from 'yup';
 export const editPlanSchema = yup.object({
   name: yup.string().required('El nombre del plan es requerido'),
   numberOfDays: yup
-    .number()
-    .required('El número de días es requerido')
-    .max(7, 'El plan no puede superar 7 días')
-    .min(1, 'El plan no puede ser menor a 1 día'),
+    .number(),
   amount: yup
     .number()
     .nullable()
     .typeError('Solo se permiten números')
     .transform((value, originalValue) => (originalValue === '' ? undefined : value)),
-
   startDate: yup
     .date()
     .required('La fecha de vigencia es requerida')

--- a/src/pages/plans/EditPlan/EditPlan.tsx
+++ b/src/pages/plans/EditPlan/EditPlan.tsx
@@ -75,19 +75,7 @@ const EditPlanForm = forwardRef<FormProps<EditPlanFormData>, EditPlanFormProps>(
         </s.InputContainer>
         <s.InputContainer>
           <s.Label>Cantidad de días por semana</s.Label>
-          <Controller
-            name="numberOfDays"
-            control={control}
-            render={({ field }) => (
-              <SpinInput
-                value={field.value}
-                onChange={field.onChange}
-                min={1}
-                max={7}
-                placeholder="Ej: 2 días"
-              />
-            )}
-          />
+          <s.Input $isNonEditable={true} value={numberOfDays} readOnly />
           <ErrorMessage error={errors.numberOfDays} />
         </s.InputContainer>
         <s.InputContainer>


### PR DESCRIPTION
Modifiqué el modal de editar Plan para que no permita editar la cantidad de días. Habíamos hablado de sacar el campo directamente, pero cuando lo probé me parece que queda más consistente hacerlo readOnly igual que el de precio.