### PR TITLE
[FTR][SLOT-316]: Implement logic for deleting a future price

### DIFF
--- a/src/app/services/PriceService.ts
+++ b/src/app/services/PriceService.ts
@@ -1,24 +1,30 @@
 import { createApi } from '@reduxjs/toolkit/query/react';
-import { UserService } from './UserService';
 import { createAuthenticatedBaseQuery } from './baseQuery';
+import { PlanService } from './PlanService';
+import { UserService } from './UserService';
 
 export const PriceService = createApi({
   reducerPath: 'prices',
   tagTypes: ['userPrices'],
   baseQuery: createAuthenticatedBaseQuery(`${import.meta.env.VITE_BACKEND_URL}/prices`),
   endpoints: (builder) => ({
-    updatePrice: builder.mutation<void, { priceId: string; amount: number }>({
-      query: ({ priceId, amount }) => ({
-        url: `${priceId}`,
-        method: 'PATCH',
-        body: { amount },
+    deletePrice: builder.mutation<void, { futurePriceId: string; planId: string }>({
+      query: ({ futurePriceId }) => ({
+        url: `/${futurePriceId}`,
+        method: 'DELETE',
       }),
-      async onQueryStarted({ priceId }, { dispatch, queryFulfilled }) {
+
+      async onQueryStarted({ planId }, { dispatch, queryFulfilled }) {
         await queryFulfilled;
-        dispatch(UserService.util.invalidateTags([{ type: 'userPrices', id: priceId }]));
+        dispatch(
+          UserService.util.invalidateTags([
+            { type: 'userPlans', id: 'LIST' }
+          ])
+        );
       },
     }),
+
   }),
 });
 
-export const { useUpdatePriceMutation } = PriceService;
+export const { useDeletePriceMutation } = PriceService;

--- a/src/app/services/PriceService.ts
+++ b/src/app/services/PriceService.ts
@@ -8,22 +8,17 @@ export const PriceService = createApi({
   tagTypes: ['userPrices'],
   baseQuery: createAuthenticatedBaseQuery(`${import.meta.env.VITE_BACKEND_URL}/prices`),
   endpoints: (builder) => ({
-    deletePrice: builder.mutation<void, { futurePriceId: string; planId: string }>({
-      query: ({ futurePriceId }) => ({
-        url: `/${futurePriceId}`,
+    deletePrice: builder.mutation<void, { priceId: string; planId: string }>({
+      query: ({ priceId: priceId }) => ({
+        url: `/${priceId}`,
         method: 'DELETE',
       }),
 
       async onQueryStarted({ planId }, { dispatch, queryFulfilled }) {
         await queryFulfilled;
-        dispatch(
-          UserService.util.invalidateTags([
-            { type: 'userPlans', id: 'LIST' }
-          ])
-        );
+        dispatch(UserService.util.invalidateTags([{ type: 'userPlans', id: 'LIST' }]));
       },
     }),
-
   }),
 });
 

--- a/src/pages/plans/FuturePrices/FuturePricesList.styles.ts
+++ b/src/pages/plans/FuturePrices/FuturePricesList.styles.ts
@@ -41,6 +41,14 @@ export const FuturePriceItem = styled.div<FuturePriceItemProps>`
   padding: 8px 0px 8px 0px;
 `;
 
+export const DeleteIcon = styled.img`
+  cursor: pointer;
+  transition: transform 0.1s ease;
+  &:hover {
+    transform: scale(1.2);
+  }
+`;
+
 export const FuturePricesListContainer = styled.div`
   display: flex;
   flex-direction: column;

--- a/src/pages/plans/FuturePrices/FuturePricesList.tsx
+++ b/src/pages/plans/FuturePrices/FuturePricesList.tsx
@@ -19,6 +19,7 @@ interface FuturePricesListProps {
   nextPrice: PriceResponse | null | undefined;
   futurePrices: PriceResponse[] | null | undefined;
   onAddPrice: () => void;
+  onDeletePrice: (price: PriceResponse) => void;
 }
 
 interface PriceItemProps {
@@ -26,10 +27,16 @@ interface PriceItemProps {
   daysUntilActive: string | React.ReactNode;
   isLast?: boolean;
   isOnlyOne?: boolean;
-  onDelete: (price: PriceResponse) => void;
+  onDeletePrice: (price: PriceResponse) => void;
 }
 
-const PriceItem = ({ price, daysUntilActive, isLast, isOnlyOne, onDelete }: PriceItemProps) => (
+const PriceItem = ({
+  price,
+  daysUntilActive,
+  isLast,
+  isOnlyOne,
+  onDeletePrice,
+}: PriceItemProps) => (
   <s.FuturePriceItem $isLast={isLast} $isOnlyOne={isOnlyOne}>
     <img src={CalendarIcon} alt="Calendar" width={20} height={20} />
     <s.PriceInfoContainer>
@@ -42,7 +49,7 @@ const PriceItem = ({ price, daysUntilActive, isLast, isOnlyOne, onDelete }: Pric
       alt="Delete"
       width={24}
       height={24}
-      onClick={() => onDelete(price)}
+      onClick={() => onDeletePrice(price)}
     />
   </s.FuturePriceItem>
 );
@@ -51,30 +58,10 @@ function FuturePricesList({
   selectedPlan,
   nextPrice,
   futurePrices,
-  onAddPrice
+  onAddPrice,
+  onDeletePrice
 }: FuturePricesListProps) {
-
   const totalFuturePrices = selectedPlan?.totalFuturePrices;
-  const [showConfirm, setShowConfirm] = useState(false);
-  const [priceToDelete, setPriceToDelete] = useState<PriceResponse | null>(null);
-
-  const [deletePrice] = useDeletePriceMutation();
-
-  const handleDeletePrice = async () => {
-    if (!priceToDelete) return;
-    deletePrice({ futurePriceId: priceToDelete.id, planId: selectedPlan?.id! })
-      .unwrap()
-      .then(() => {
-        toast.success('Precio eliminado');
-        setShowConfirm(false);
-        setPriceToDelete(null);
-      });
-  };
-
-  const handleOpenConfirm = (price: PriceResponse) => {
-    setPriceToDelete(price);
-    setShowConfirm(true);
-  };
 
   return (
     <s.FuturePricesContainer>
@@ -96,7 +83,7 @@ function FuturePricesList({
             }
             isLast={!futurePrices?.length}
             isOnlyOne={totalFuturePrices === 1}
-            onDelete={handleOpenConfirm}
+            onDeletePrice={onDeletePrice}
           />
         )}
         {futurePrices?.map((price, index) => (
@@ -109,7 +96,7 @@ function FuturePricesList({
               </s.DaysUntilActiveComp>
             }
             isLast={index === futurePrices.length - 1}
-            onDelete={handleOpenConfirm}
+            onDeletePrice={onDeletePrice}
           />
         ))}
       </s.FuturePricesListContainer>
@@ -122,15 +109,6 @@ function FuturePricesList({
       >
         Programar nuevo precio
       </Button>
-      <Modal
-        onCancel={() => setShowConfirm(false)}
-        active={showConfirm}
-        onConfirm={handleDeletePrice}
-        primaryButtonText="Aceptar"
-        secondaryButtonText="Cancelar"
-      >
-        <ConfirmDialog message="¿Estás seguro de que quieres eliminar este precio?" />
-      </Modal>
     </s.FuturePricesContainer>
   );
 }

--- a/src/pages/plans/FuturePrices/FuturePricesList.tsx
+++ b/src/pages/plans/FuturePrices/FuturePricesList.tsx
@@ -8,6 +8,11 @@ import { formatDateReverse } from '../../../utils/DateFormatter';
 import Button from '../../../components/button/Button';
 import AddIcon from '../../../assets/add-icon.svg';
 import { Tooltip } from '../../../components/tooltip/Tooltip';
+import { useDeletePriceMutation } from '../../../app/services/PriceService';
+import toast from 'react-hot-toast';
+import { useState } from 'react';
+import Modal from '../../../components/unified_modal/Modal';
+import { ConfirmDialog } from '../../../components/confirm_dialog/ConfirmDialog';
 
 interface FuturePricesListProps {
   selectedPlan: PlanResponse | null | undefined;
@@ -21,9 +26,10 @@ interface PriceItemProps {
   daysUntilActive: string | React.ReactNode;
   isLast?: boolean;
   isOnlyOne?: boolean;
+  onDelete: (price: PriceResponse) => void;
 }
 
-const PriceItem = ({ price, daysUntilActive, isLast, isOnlyOne }: PriceItemProps) => (
+const PriceItem = ({ price, daysUntilActive, isLast, isOnlyOne, onDelete }: PriceItemProps) => (
   <s.FuturePriceItem $isLast={isLast} $isOnlyOne={isOnlyOne}>
     <img src={CalendarIcon} alt="Calendar" width={20} height={20} />
     <s.PriceInfoContainer>
@@ -31,7 +37,13 @@ const PriceItem = ({ price, daysUntilActive, isLast, isOnlyOne }: PriceItemProps
       <s.StartDate>{formatDateReverse(price.startDate)}</s.StartDate>
     </s.PriceInfoContainer>
     {daysUntilActive}
-    <img src={DeleteIcon} alt="Delete" width={24} height={24} />
+    <s.DeleteIcon
+      src={DeleteIcon}
+      alt="Delete"
+      width={24}
+      height={24}
+      onClick={() => onDelete(price)}
+    />
   </s.FuturePriceItem>
 );
 
@@ -39,9 +51,31 @@ function FuturePricesList({
   selectedPlan,
   nextPrice,
   futurePrices,
-  onAddPrice,
+  onAddPrice
 }: FuturePricesListProps) {
+
   const totalFuturePrices = selectedPlan?.totalFuturePrices;
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [priceToDelete, setPriceToDelete] = useState<PriceResponse | null>(null);
+
+  const [deletePrice] = useDeletePriceMutation();
+
+  const handleDeletePrice = async () => {
+    if (!priceToDelete) return;
+    deletePrice({ futurePriceId: priceToDelete.id, planId: selectedPlan?.id! })
+      .unwrap()
+      .then(() => {
+        toast.success('Precio eliminado');
+        setShowConfirm(false);
+        setPriceToDelete(null);
+      });
+  };
+
+  const handleOpenConfirm = (price: PriceResponse) => {
+    setPriceToDelete(price);
+    setShowConfirm(true);
+  };
+
   return (
     <s.FuturePricesContainer>
       <s.Subtitle>
@@ -62,6 +96,7 @@ function FuturePricesList({
             }
             isLast={!futurePrices?.length}
             isOnlyOne={totalFuturePrices === 1}
+            onDelete={handleOpenConfirm}
           />
         )}
         {futurePrices?.map((price, index) => (
@@ -74,6 +109,7 @@ function FuturePricesList({
               </s.DaysUntilActiveComp>
             }
             isLast={index === futurePrices.length - 1}
+            onDelete={handleOpenConfirm}
           />
         ))}
       </s.FuturePricesListContainer>
@@ -86,6 +122,15 @@ function FuturePricesList({
       >
         Programar nuevo precio
       </Button>
+      <Modal
+        onCancel={() => setShowConfirm(false)}
+        active={showConfirm}
+        onConfirm={handleDeletePrice}
+        primaryButtonText="Aceptar"
+        secondaryButtonText="Cancelar"
+      >
+        <ConfirmDialog message="¿Estás seguro de que quieres eliminar este precio?" />
+      </Modal>
     </s.FuturePricesContainer>
   );
 }

--- a/src/pages/plans/FuturePrices/FuturePricesList.tsx
+++ b/src/pages/plans/FuturePrices/FuturePricesList.tsx
@@ -8,11 +8,6 @@ import { formatDateReverse } from '../../../utils/DateFormatter';
 import Button from '../../../components/button/Button';
 import AddIcon from '../../../assets/add-icon.svg';
 import { Tooltip } from '../../../components/tooltip/Tooltip';
-import { useDeletePriceMutation } from '../../../app/services/PriceService';
-import toast from 'react-hot-toast';
-import { useState } from 'react';
-import Modal from '../../../components/unified_modal/Modal';
-import { ConfirmDialog } from '../../../components/confirm_dialog/ConfirmDialog';
 
 interface FuturePricesListProps {
   selectedPlan: PlanResponse | null | undefined;

--- a/src/pages/plans/Plans.tsx
+++ b/src/pages/plans/Plans.tsx
@@ -29,6 +29,8 @@ import BicycleLoader from '../../components/bicycle_animation/BicycleLoader';
 import Modal, { type ModalProps } from '../../components/unified_modal/Modal';
 import FuturePricesList from './FuturePrices/FuturePricesList';
 import FuturePricesComponent from './FuturePrices/FuturePricesComponent';
+import type { PriceResponse } from '../../app/types/responses/PriceResponse.type';
+import { useDeletePriceMutation } from '../../app/services/PriceService';
 
 enum ModalType {
   DELETE = 'DELETE',
@@ -36,6 +38,7 @@ enum ModalType {
   EDIT = 'EDIT',
   NONE = 'NONE',
   SHOW_FUTURE_PRICES = 'SHOW_FUTURE_PRICES',
+  DELETE_PRICE = 'DELETE_PRICE',
 }
 
 function Plans() {
@@ -137,7 +140,28 @@ function Plans() {
     setShowModal(true);
   };
 
-  const updatedSelectedPlan = plansData?.content.find(p => p.id === selectedPlan?.id) ?? selectedPlan;
+  const [priceToDelete, setPriceToDelete] = useState<PriceResponse | null>(null);
+
+  const [deletePrice] = useDeletePriceMutation();
+
+  const handleDeletePrice = async () => {
+    if (!priceToDelete) return;
+    await deletePrice({ priceId: priceToDelete.id, planId: selectedPlan?.id! })
+      .unwrap()
+      .then(() => {
+        toast.success('Precio eliminado');
+        setPriceToDelete(null);
+      });
+    openModal(ModalType.SHOW_FUTURE_PRICES);
+  };
+
+  const handleOpenDeletePrice = (price: PriceResponse) => {
+    setPriceToDelete(price);
+    openModal(ModalType.DELETE_PRICE);
+  };
+
+  const updatedSelectedPlan =
+    plansData?.content.find((p) => p.id === selectedPlan?.id) ?? selectedPlan;
 
   const modalConfig: Record<ModalType, ModalProps> = {
     [ModalType.DELETE]: {
@@ -182,6 +206,7 @@ function Plans() {
             setShowCompleteEdit(false);
             openModal(ModalType.EDIT);
           }}
+          onDeletePrice={handleOpenDeletePrice}
         />
       ),
       title: 'Próximos precios',
@@ -189,6 +214,13 @@ function Plans() {
         setModalType(ModalType.NONE);
         setShowModal(false);
       },
+    },
+    [ModalType.DELETE_PRICE]: {
+      children: <ConfirmDialog message="¿Estás seguro de que quieres eliminar este precio?" />,
+      primaryButtonText: 'Aceptar',
+      secondaryButtonText: 'Cancelar',
+      onConfirm: handleDeletePrice,
+      onCancel: () => openModal(ModalType.SHOW_FUTURE_PRICES),
     },
   };
 

--- a/src/pages/plans/Plans.tsx
+++ b/src/pages/plans/Plans.tsx
@@ -59,12 +59,12 @@ function Plans() {
   } = useGetUserPlansQuery(
     userId
       ? {
-          userId,
-          page: page - 1,
-          size,
-          planName: filter,
-          sort: sort.length > 0 ? sort : undefined,
-        }
+        userId,
+        page: page - 1,
+        size,
+        planName: filter,
+        sort: sort.length > 0 ? sort : undefined,
+      }
       : skipToken,
   );
 
@@ -137,6 +137,8 @@ function Plans() {
     setShowModal(true);
   };
 
+  const updatedSelectedPlan = plansData?.content.find(p => p.id === selectedPlan?.id) ?? selectedPlan;
+
   const modalConfig: Record<ModalType, ModalProps> = {
     [ModalType.DELETE]: {
       children: <ConfirmDialog message="¿Estás seguro de que deseas eliminar este plan?" />,
@@ -173,9 +175,9 @@ function Plans() {
     [ModalType.SHOW_FUTURE_PRICES]: {
       children: (
         <FuturePricesList
-          selectedPlan={selectedPlan}
-          nextPrice={selectedPlan?.nextPrice}
-          futurePrices={selectedPlan?.futurePrices}
+          selectedPlan={updatedSelectedPlan}
+          nextPrice={updatedSelectedPlan?.nextPrice}
+          futurePrices={updatedSelectedPlan?.futurePrices}
           onAddPrice={() => {
             setShowCompleteEdit(false);
             openModal(ModalType.EDIT);

--- a/src/pages/plans/Plans.tsx
+++ b/src/pages/plans/Plans.tsx
@@ -221,6 +221,7 @@ function Plans() {
       secondaryButtonText: 'Cancelar',
       onConfirm: handleDeletePrice,
       onCancel: () => openModal(ModalType.SHOW_FUTURE_PRICES),
+      onClose: () => openModal(ModalType.SHOW_FUTURE_PRICES),
     },
   };
 
@@ -354,6 +355,7 @@ function Plans() {
         primaryButtonText={modalConfig[modalType].primaryButtonText}
         secondaryButtonText={modalConfig[modalType].secondaryButtonText}
         onConfirm={modalConfig[modalType].onConfirm}
+        onCancel={modalConfig[modalType].onCancel ?? (() => setShowModal(false))}
         onClose={modalConfig[modalType].onClose}
       >
         {modalConfig[modalType].children}

--- a/src/pages/plans/Plans.tsx
+++ b/src/pages/plans/Plans.tsx
@@ -354,7 +354,6 @@ function Plans() {
         primaryButtonText={modalConfig[modalType].primaryButtonText}
         secondaryButtonText={modalConfig[modalType].secondaryButtonText}
         onConfirm={modalConfig[modalType].onConfirm}
-        onCancel={() => setShowModal(false)}
         onClose={modalConfig[modalType].onClose}
       >
         {modalConfig[modalType].children}

--- a/src/pages/slots/SlotConfiguration.styles.ts
+++ b/src/pages/slots/SlotConfiguration.styles.ts
@@ -142,8 +142,8 @@ export const Button = styled.button<ButtonProps>`
   color: ${DEFAULT_TEXT_COLOR};
   &:hover {
     ${(props) =>
-    !props.$isDisabled &&
-    `
+      !props.$isDisabled &&
+      `
             cursor: pointer;
             background: ${NEUTRAL_COLOR};
         `}


### PR DESCRIPTION
Se agregó la integración con el backend para eliminar un precio programado desde la lista de precios futuros:
- Se añadió el servicio correspondiente y se eliminó uno viejo
- Se añadió la lógica correspondiente para que al clickear sobre el icono de eliminar, se tome el id del precio a eliminar, se realice el eliminado confirmando a través del modal de confirmación y se refresque tanto la lista como la tabla de manera simultánea